### PR TITLE
修复一个构建时候源码最后一行有注释的时候的bug

### DIFF
--- a/src/parse/require-node-list.js
+++ b/src/parse/require-node-list.js
@@ -14,7 +14,7 @@ var console = require('blear.node.console');
 
 var Uglify = require("uglify-js");
 var beforeWrap = 'function parseNodeList(){';
-var afterWrap = '}';
+var afterWrap = '\n}';
 
 module.exports = function (file, code, async) {
     var ast;


### PR DESCRIPTION
比如源码长这个样子：
```
alert(1)
// alert(2)
```
构建时包装成这样了：
```
function parseNodeList(){alert(1)
// alert(2)}
```
就语法错误了。